### PR TITLE
Add calling card page

### DIFF
--- a/calling-card.html
+++ b/calling-card.html
@@ -1,0 +1,414 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tom Delaporte · TDcatalyst</title>
+  <meta name="description" content="Experiential strategic framing based on millenary practices of adaptability for executives leading the AI transformation." />
+  <meta property="og:title" content="Tom Delaporte · TDcatalyst" />
+  <meta property="og:description" content="Experiential strategic framing based on millenary practices of adaptability for executives leading the AI transformation." />
+  <meta property="og:url" content="https://tdcatalyst.com/calling-card.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --offwhite:        #EBEFEC;
+      --seamist:         #D9E2E6;
+      --navy:            #1F3A5F;
+      --charcoal:        #222222;
+      --midgray:         #6B6B6B;
+      --hairline:        #D9D3CA;
+      --logo-red:        #C44536;
+      --logo-gold:       #D4A84B;
+      --logo-blue:       #4A7C9E;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      background: var(--offwhite);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.25rem;
+    }
+
+    /* ── Outer shell ── */
+    .card-wrap {
+      width: 100%;
+      max-width: 860px;
+    }
+
+    .calling-card {
+      background: #fff;
+      border-radius: 3px;
+      overflow: hidden;
+      box-shadow:
+        0 2px 8px  rgba(31, 58, 95, 0.08),
+        0 8px 40px rgba(31, 58, 95, 0.14);
+    }
+
+    /* ── Landscape: Pacifica coast ── */
+    .card-landscape {
+      position: relative;
+      aspect-ratio: 16 / 6;
+      background: var(--navy);
+      overflow: hidden;
+    }
+
+    .card-landscape img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center 45%;
+      display: block;
+    }
+
+    .card-landscape-overlay {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(
+        160deg,
+        rgba(31, 58, 95, 0.15) 0%,
+        rgba(31, 58, 95, 0.40) 50%,
+        rgba(31, 58, 95, 0.78) 100%
+      );
+    }
+
+    /* Land acknowledgment watermark on the landscape */
+    .card-land-note {
+      position: absolute;
+      bottom: 1.1rem;
+      left: 1.8rem;
+      font-family: 'Inter', sans-serif;
+      font-size: 0.72rem;
+      letter-spacing: 0.10em;
+      text-transform: uppercase;
+      color: rgba(217, 226, 230, 0.75);
+    }
+
+    /* ── Three-color accent bar ── */
+    .color-bar {
+      display: flex;
+      height: 4px;
+    }
+    .color-bar .b-red  { flex: 1; background: var(--logo-red); }
+    .color-bar .b-gold { flex: 1; background: var(--logo-gold); }
+    .color-bar .b-blue { flex: 1; background: var(--logo-blue); }
+
+    /* ── Card body ── */
+    .card-body {
+      padding: 2.4rem 2.6rem 2rem;
+      display: grid;
+      grid-template-columns: 1fr 220px;
+      gap: 2rem 3rem;
+      align-items: start;
+    }
+
+    /* ── Left: identity ── */
+    .card-main {}
+
+    .card-logo-wrap {
+      margin-bottom: 1.4rem;
+    }
+    .card-logo {
+      height: 48px;
+      width: auto;
+      display: block;
+    }
+
+    .card-name {
+      font-family: 'Fraunces', Georgia, serif;
+      font-weight: 400;
+      font-size: 1.9rem;
+      color: var(--navy);
+      letter-spacing: -0.02em;
+      line-height: 1.1;
+      margin-bottom: 0.3rem;
+    }
+
+    .card-role {
+      font-size: 0.76rem;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--midgray);
+      margin-bottom: 1.4rem;
+    }
+
+    /* Decorative three-line motif echoing the logo strokes */
+    .card-lines {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+      margin-bottom: 1.3rem;
+      max-width: 120px;
+    }
+    .card-lines span { display: block; height: 2.5px; border-radius: 2px; }
+    .card-lines .l-red  { background: var(--logo-red);  width: 100%; }
+    .card-lines .l-gold { background: var(--logo-gold); width: 70%; }
+    .card-lines .l-blue { background: var(--logo-blue); width: 44%; }
+
+    .card-tagline {
+      font-family: 'Fraunces', serif;
+      font-style: italic;
+      font-weight: 300;
+      font-size: 1.02rem;
+      color: var(--navy);
+      line-height: 1.55;
+      max-width: 40ch;
+    }
+
+    /* ── Right: contact ── */
+    .card-contact {
+      padding-top: 0.3rem;
+    }
+
+    .contact-item {
+      margin-bottom: 1.4rem;
+    }
+
+    .contact-label {
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--midgray);
+      margin-bottom: 0.35rem;
+    }
+
+    .contact-value {
+      font-size: 0.875rem;
+      color: var(--navy);
+      font-weight: 500;
+      line-height: 1.4;
+    }
+
+    .contact-value a {
+      color: var(--navy);
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+    .contact-value a:hover { color: var(--logo-blue); }
+
+    /* LinkedIn icon */
+    .li-icon {
+      width: 13px;
+      height: 13px;
+      vertical-align: middle;
+      margin-right: 5px;
+      margin-top: -2px;
+      flex-shrink: 0;
+    }
+
+    /* QR placeholder — print-friendly */
+    .qr-placeholder {
+      width: 80px;
+      height: 80px;
+      border: 1px solid var(--hairline);
+      border-radius: 2px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 1.6rem;
+      background: var(--offwhite);
+    }
+    .qr-placeholder svg {
+      width: 44px;
+      height: 44px;
+      opacity: 0.35;
+    }
+    .qr-label {
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--midgray);
+      margin-top: 0.4rem;
+    }
+
+    /* ── Navy footer strip ── */
+    .card-footer-strip {
+      background: var(--navy);
+      padding: 1rem 2.6rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+
+    .card-footer-strip .brand {
+      font-family: 'Fraunces', serif;
+      font-size: 0.95rem;
+      font-weight: 300;
+      color: var(--offwhite);
+      letter-spacing: 0.02em;
+    }
+
+    .card-footer-strip .footer-url {
+      font-size: 0.8rem;
+      color: rgba(217, 226, 230, 0.75);
+      letter-spacing: 0.06em;
+      font-weight: 400;
+    }
+
+    /* ── Below-card utility row ── */
+    .card-actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 1.5rem;
+      margin-top: 1.4rem;
+    }
+
+    .card-actions a {
+      font-family: 'Inter', sans-serif;
+      font-size: 0.8rem;
+      color: var(--midgray);
+      text-decoration: none;
+      letter-spacing: 0.04em;
+      border-bottom: 1px solid transparent;
+      transition: color 0.2s, border-color 0.2s;
+    }
+    .card-actions a:hover { color: var(--navy); border-bottom-color: var(--navy); }
+
+    .card-actions .sep {
+      color: var(--hairline);
+      font-size: 0.75rem;
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 620px) {
+      .card-body {
+        grid-template-columns: 1fr;
+        padding: 1.8rem 1.6rem 1.6rem;
+        gap: 1.8rem;
+      }
+      .card-landscape { aspect-ratio: 16 / 8; }
+      .card-footer-strip { padding: 0.9rem 1.6rem; flex-direction: column; align-items: flex-start; gap: 0.35rem; }
+      .card-tagline { max-width: 100%; }
+      .qr-placeholder { display: none; }
+    }
+
+    /* ── Print ── */
+    @media print {
+      body { background: #fff; padding: 0; }
+      .calling-card { box-shadow: none; }
+      .card-actions { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="card-wrap">
+  <div class="calling-card">
+
+    <!-- Pacifica coastline — Aramai band of the Ramaytush Ohlone ancestral territory -->
+    <div class="card-landscape">
+      <img
+        src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?auto=format&fit=crop&w=1600&q=82"
+        alt="Pacific coastline — Pacifica, ancestral lands of the Aramai band of the Ramaytush Ohlone"
+        onerror="this.style.background='var(--navy)'; this.style.display='none';"
+      >
+      <div class="card-landscape-overlay"></div>
+      <div class="card-land-note">Pacifica · Aramai band of the Ramaytush Ohlone · ancestral territory</div>
+    </div>
+
+    <!-- Three-color accent bar -->
+    <div class="color-bar" aria-hidden="true">
+      <span class="b-red"></span>
+      <span class="b-gold"></span>
+      <span class="b-blue"></span>
+    </div>
+
+    <!-- Card body -->
+    <div class="card-body">
+
+      <!-- Identity column -->
+      <div class="card-main">
+        <div class="card-logo-wrap">
+          <img src="images/logo-full.jpg" alt="TDcatalyst" class="card-logo">
+        </div>
+
+        <div class="card-name">Tom Delaporte</div>
+        <div class="card-role">Founder · TDcatalyst</div>
+
+        <!-- Converging-strokes motif -->
+        <div class="card-lines" aria-hidden="true">
+          <span class="l-red"></span>
+          <span class="l-gold"></span>
+          <span class="l-blue"></span>
+        </div>
+
+        <p class="card-tagline">Experiential strategic framing based on millenary practices of adaptability for executives leading the AI transformation</p>
+      </div>
+
+      <!-- Contact column -->
+      <div class="card-contact">
+
+        <div class="contact-item">
+          <div class="contact-label">Web</div>
+          <div class="contact-value">
+            <a href="https://tdcatalyst.com">tdcatalyst.com</a>
+          </div>
+        </div>
+
+        <div class="contact-item">
+          <div class="contact-label">LinkedIn</div>
+          <div class="contact-value">
+            <a href="https://www.linkedin.com/company/tdcatalyst/" target="_blank" rel="noopener">
+              <svg class="li-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+              </svg>
+              /company/tdcatalyst
+            </a>
+          </div>
+        </div>
+
+        <div class="contact-item">
+          <div class="contact-label">Begin</div>
+          <div class="contact-value">
+            <a href="https://tdcatalyst.com/begin.html">tdcatalyst.com/begin</a>
+          </div>
+        </div>
+
+        <!-- QR placeholder (swap for a real QR at print time) -->
+        <div class="qr-placeholder" title="Scan to visit tdcatalyst.com">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <rect x="3" y="3" width="7" height="7" rx="0.5"/>
+            <rect x="14" y="3" width="7" height="7" rx="0.5"/>
+            <rect x="3" y="14" width="7" height="7" rx="0.5"/>
+            <rect x="5" y="5" width="3" height="3" fill="currentColor" stroke="none"/>
+            <rect x="16" y="5" width="3" height="3" fill="currentColor" stroke="none"/>
+            <rect x="5" y="16" width="3" height="3" fill="currentColor" stroke="none"/>
+            <path d="M14 14h2v2h-2zM16 16h2v2h-2zM18 14h2v2h-2zM14 18h2v2h-2zM18 18h2v2h-2z" fill="currentColor" stroke="none"/>
+          </svg>
+        </div>
+        <div class="qr-label">tdcatalyst.com</div>
+
+      </div>
+    </div>
+
+    <!-- Navy footer -->
+    <div class="card-footer-strip">
+      <span class="brand">Precision &middot; Catalysis &middot; Momentum</span>
+      <span class="footer-url">tdcatalyst.com</span>
+    </div>
+
+  </div>
+
+  <!-- Below-card utility links -->
+  <div class="card-actions">
+    <a href="index.html">Visit TDcatalyst.com</a>
+    <span class="sep">·</span>
+    <a href="begin.html">Begin a conversation</a>
+    <span class="sep">·</span>
+    <a href="javascript:window.print()">Print card</a>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `calling-card.html` — a standalone digital business card for tdcatalyst.com
- Features the TDcatalyst logo, a Pacifica coastline photo (Aramai band of the Ramaytush Ohlone ancestral territory), the three-color red/gold/blue accent system, LinkedIn link, and the full tagline
- Fully responsive, includes print styles, no dependency on `style.css`

## What's on the card
- **Logo** — `images/logo-full.jpg`
- **Landscape** — Pacific coastal headlands photo with Aramai land acknowledgment watermark
- **Tagline** — *Experiential strategic framing based on millenary practices of adaptability for executives leading the AI transformation*
- **Links** — tdcatalyst.com, LinkedIn (/company/tdcatalyst/), Begin page
- **QR placeholder** — swap in a real QR code before printing
- **Footer** — Precision · Catalysis · Momentum

## Live URL after merge
`https://tdcatalyst.com/calling-card.html`

https://claude.ai/code/session_01XPjng1653rBCLpYonDns7a

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPjng1653rBCLpYonDns7a)_