### PR TITLE
Update seams article: replace 'pressure vessel' phrase

### DIFF
--- a/field-note-the-seams.html
+++ b/field-note-the-seams.html
@@ -113,7 +113,7 @@
 
     <p>BetterUp&#x2019;s research identifies managers as the single biggest lever in AI adoption outcomes.<sup><a href="#ref-1">[1]</a></sup> Not tools. Not training budgets. Not executive mandates. Managers&#x2014;because they set the team-level interpretation of every leadership signal. They decide, in practice, whether AI adoption is a threat or an opportunity. They shape whether their team members experiment or retreat.</p>
 
-    <p>But most AI transformation programs design for the extremes. They give executives the vision work and frontline employees the training. Managers get a deck to cascade and a mandate to enforce compliance. That is not a change management strategy. That is a pressure vessel.</p>
+    <p>But most AI transformation programs design for the extremes. They give executives the vision work and frontline employees the training. Managers get a deck to cascade and a mandate to enforce compliance. That is not a change management strategy. That is a signal that they don't realize what true change requires.</p>
 
     <p>What the middle management layer actually needs is different: permission to learn out loud, a clear answer to &#x201C;what does this mean for my team&#x2019;s work,&#x201D; and a protected space to redesign workflows at the unit level before those workflows get handed back up as precedents.</p>
 


### PR DESCRIPTION
Changed 'That is a pressure vessel' to 'That is a signal that they don't realize what true change requires.' to better capture the concept that managers are being set up without proper support.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEnTT3mBmXUq5kBF9ZPmHs)_