### PR TITLE
Update about section: replace 'operator-side workforce programs' with 'people operations and transformation'

### DIFF
--- a/about.html
+++ b/about.html
@@ -79,7 +79,7 @@
   <div class="wrap narrow">
 
     <h2>Practice</h2>
-    <p><span class="lead-phrase">Tom Delaporte founded TDcatalyst</span> after building and running transformation programs at the intersection of AI product, enterprise consulting, and operator-side workforce programs — three domains that rarely meet in a single practitioner.</p>
+    <p><span class="lead-phrase">Tom Delaporte founded TDcatalyst</span> after building and running transformation programs at the intersection of AI product, enterprise consulting, people operations and transformation — three domains that rarely meet in a single practitioner.</p>
     <p>The typical client is a mid to large enterprise transformation, AI, or workforce leader with accountability for how AI enters the operating model. Founders seeking enterprise readiness are welcome and often find the diagnostic engagement a fit.</p>
 
     <hr class="rule">


### PR DESCRIPTION
Update the about section to replace "operator-side workforce programs" with "people operations and transformation".

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXWPyZRoDATMYqHUZivKYJ)_