### PR TITLE
Sessions: add What every engagement produces section

### DIFF
--- a/sessions.html
+++ b/sessions.html
@@ -51,6 +51,40 @@
   </div>
 </section>
 
+<!-- WHAT THE ENGAGEMENT PRODUCES -->
+<section class="alt">
+  <div class="wrap">
+    <div class="section-head">
+      <div class="eyebrow">What every engagement produces</div>
+      <h2>A written diagnostic. Four areas. Every finding specific.</h2>
+      <p>Every engagement concludes with a structured written output delivered within 7 to 10 days. The format and depth vary by tier. The four areas are consistent across all tiers.</p>
+    </div>
+    <div class="outcomes-grid">
+      <div class="outcome-item">
+        <div class="outcome-num">01</div>
+        <h3>Named adaptive challenge</h3>
+        <p>A precise, written statement of the gap between your organization's current posture and the leadership capability the AI transition demands of it. Named, not generalized.</p>
+      </div>
+      <div class="outcome-item">
+        <div class="outcome-num">02</div>
+        <h3>Organizational landscape analysis</h3>
+        <p>A structured read of the signals, assets, and constraints your operating environment is already producing. What your landscape is showing you, and what it is obscuring.</p>
+      </div>
+      <div class="outcome-item">
+        <div class="outcome-num">03</div>
+        <h3>Leverage inventory</h3>
+        <p>The specific capabilities, structural advantages, and resources available to close the identified gap. An honest accounting of what is present, what is absent, and what is misallocated.</p>
+      </div>
+      <div class="outcome-item">
+        <div class="outcome-num">04</div>
+        <h3>90-day starting roadmap</h3>
+        <p>A sequenced set of first moves with clear ownership and decision points. Built to act before the signal hardens, not after. PDF delivery within 7 to 10 days, 12 to 20 pages for a full-day engagement.</p>
+      </div>
+    </div>
+    <p style="margin-top:1.5rem; font-size:0.92rem; color:var(--midgray);">Every claim traceable. Every recommendation specific to the session.</p>
+  </div>
+</section>
+
 <!-- FOUR TIERS -->
 <section id="tiers">
   <div class="wrap tiers-stack">


### PR DESCRIPTION
Mirrors the four-area diagnostic framing from index.html on sessions.html, placed between the hero and the four tiers. Drops the self-referential See what each tier delivers link.