### PR TITLE
Replace cliché messaging in about section

### DIFF
--- a/about.html
+++ b/about.html
@@ -60,7 +60,7 @@
     <div class="outcomes-grid">
       <div class="outcome-item">
         <h3>A method sourced and tested</h3>
-        <p>The five frameworks draw on Dynamic Capabilities (Teece, UC Berkeley), Organizational Ambidexterity (O&#x2019;Reilly and Tushman, Stanford and Harvard), and Sensing and Responding (Burnard and Bhamra). They have been tested against real enterprise transformation contexts, not constructed for a slide deck.</p>
+        <p>The five frameworks draw on Dynamic Capabilities (Teece, UC Berkeley), Organizational Ambidexterity (O&#x2019;Reilly and Tushman, Stanford and Harvard), and Sensing and Responding (Burnard and Bhamra). They are applied and refined through transformation work across Fortune 100 enterprises and public sector organizations, with measurable outcomes throughout.</p>
       </div>
       <div class="outcome-item">
         <h3>A landscape 3,000 years in the making</h3>


### PR DESCRIPTION
Replace "They have been tested against real enterprise transformation contexts, not constructed for a slide deck" with more authentic language emphasizing measurable outcomes and commercial accountability.

The new text is: "They are applied and refined through transformation work across Fortune 100 enterprises and public sector organizations, with measurable outcomes throughout."

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnEQ6sMvVgEPtnx9y44Zky)_