### PR TITLE
Replace landscape messaging with breakthrough-focused language

### DIFF
--- a/about.html
+++ b/about.html
@@ -64,7 +64,7 @@
       </div>
       <div class="outcome-item">
         <h3>A landscape 3,000 years in the making</h3>
-        <p>The Aramai band of the Ramaytush Ohlone people read the Pacifica coastline as a continuous source of strategic information for over three millennia. TDcatalyst operates on their ancestral territory and uses that landscape as the setting for every field engagement. The land is part of the method, not a backdrop to it.</p>
+        <p>The Aramai band of the Ramaytush Ohlone people read the Pacifica coastline as a continuous source of strategic information for over three millennia. TDcatalyst operates on their ancestral territory and uses that landscape as the setting for every field engagement. The cognitive posture embodied reflection brings is the type of environment that generates breakthroughs.</p>
       </div>
       <div class="outcome-item">
         <h3>Operator accountability</h3>


### PR DESCRIPTION
Replace "The land is part of the method, not a backdrop to it" with more impactful messaging: "The cognitive posture embodied reflection brings is the type of environment that generates breakthroughs."

This better captures the transformative effect of the landscape setting on the work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnEQ6sMvVgEPtnx9y44Zky)_