### PR TITLE
Replace trigger-based CTA with value-focused impact statement

### DIFF
--- a/begin.html
+++ b/begin.html
@@ -42,7 +42,7 @@
     <div class="eyebrow">Begin</div>
     <h1>Most AI programs stall in the same place.</h1>
     <p class="hero-sub">Not at the model. Not at the budget. At the seam between AI product, operations, and people, where new technology enters the workforce and the org chart has not caught up. Pilots that will not convert. Teams reorganized three times in eighteen months. A board asking how the work changes, and no one with the three disciplines to answer.</p>
-    <p class="hero-sub" style="margin-top:1rem;">TDcatalyst advises the leaders working that seam. Reach out when it is time to stop running pilots and start building adaptability.</p>
+    <p class="hero-sub" style="margin-top:1rem;">TDcatalyst advises the leaders working that seam. Our impact is accompanying you with the language, framing, and actions that build your organization's adaptability.</p>
   </div>
 </section>
 


### PR DESCRIPTION
Replace trigger-based call to action with value-focused impact statement.

New text: "Our impact is accompanying you with the language, framing, and actions that build your organization's adaptability."

This shifts from timing-based messaging ("when it is time to...") to outcome/value-based messaging that clarifies what TDcatalyst delivers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnEQ6sMvVgEPtnx9y44Zky)_