### PR TITLE
Remove 'of it.' from leadership capability sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
       <div class="outcome-item">
         <div class="outcome-num">01</div>
         <h3>Named adaptive challenge</h3>
-        <p>A precise, written statement of the gap between your organization's current posture and the leadership capability the AI transition demands of it. Named, not generalized.</p>
+        <p>A precise, written statement of the gap between your organization's current posture and the leadership capability the AI transition demands. Named, not generalized.</p>
       </div>
       <div class="outcome-item">
         <div class="outcome-num">02</div>

--- a/sessions.html
+++ b/sessions.html
@@ -63,7 +63,7 @@
       <div class="outcome-item">
         <div class="outcome-num">01</div>
         <h3>Named adaptive challenge</h3>
-        <p>A precise, written statement of the gap between your organization's current posture and the leadership capability the AI transition demands of it. Named, not generalized.</p>
+        <p>A precise, written statement of the gap between your organization's current posture and the leadership capability the AI transition demands. Named, not generalized.</p>
       </div>
       <div class="outcome-item">
         <div class="outcome-num">02</div>


### PR DESCRIPTION
Simplifies the sentence from "the leadership capability the AI transition demands of it" to "the leadership capability the AI transition demands" for clarity and better readability.

Changes made in both index.html and sessions.html.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W39dyRRdPsiPMfG2hdXgqw)_