### PR TITLE
Sharpen one-pager opening with field notes positioning

### DIFF
--- a/one-pager.html
+++ b/one-pager.html
@@ -161,7 +161,7 @@
 
     <!-- THE OFFER -->
     <div class="op-thesis" style="margin-top: 0; margin-bottom: 2rem;">
-      <p><strong>The thesis:</strong> Organizations ask how to deploy AI effectively. The consequential question is what leadership AI makes necessary. As AI absorbs the performance layer, what remains human is the adaptability layer—reading complex signals in real time and acting with complete ownership before competitors notice.</p>
+      <p><strong>The problem:</strong> Organizations are asking individuals to use AI in their daily tasks. Vague guidance. Execution pressure. Uncertainty about what success looks like. This creates the flaws described in the field notes—unmarked passages where leaders don't know what they're missing, where the language of project management has no concept of marking. <strong>The consequential question is what leadership AI makes necessary.</strong> As AI absorbs the performance layer, what remains irreducibly human is the adaptability layer—reading complex signals in real time and acting with complete ownership before competitors notice.</p>
     </div>
 
     <!-- WHO & WHAT -->


### PR DESCRIPTION
Update one-pager opening to reflect field notes positioning.

Reframes the problem from vague "deploy AI effectively" to concrete reality: "asking individuals to use AI in daily tasks" with vague guidance and execution pressure. Ties directly to field notes language about unmarked passages and the absence of marking in project management frameworks.

This grounds the offer in the specific gaps the practice addresses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4HcbSaw5QMzrtabDHHh8N)_