### PR TITLE
Update core value proposition with specific seams

### DIFF
--- a/one-pager.html
+++ b/one-pager.html
@@ -161,7 +161,7 @@
 
     <!-- THE CORE VALUE PROP -->
     <div class="op-thesis">
-      <p><strong>TDcatalyst advises the leaders working that seam</strong>—between the imperative to deploy AI and the capability to lead adaptably through it. Our impact is accompanying you with the language, framing, and actions that build your organization's adaptability.</p>
+      <p><strong>TDcatalyst advises the leaders working the seams</strong> between AI product, adoption/change agility, and people management. Our impact is accompanying you with the language, framing, and actions that build your organization's adaptability.</p>
     </div>
 
     <hr class="op-divider">


### PR DESCRIPTION
Update core value proposition to specify three seams.

Changes opening from generic "that seam" to concrete intersection:
- AI product
- Adoption/change agility
- People management

Clarifies the exact domain where TDcatalyst advises leaders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4HcbSaw5QMzrtabDHHh8N)_