### PR TITLE
Add landscape reasoning section to one-pager

### DIFF
--- a/one-pager.html
+++ b/one-pager.html
@@ -185,6 +185,15 @@
 
     <hr class="op-divider">
 
+    <!-- WHY THE LANDSCAPE -->
+    <div>
+      <div class="eyebrow">WHY THE LANDSCAPE MATTERS</div>
+      <h2>The pace of a walk changes what leaders notice.</h2>
+      <p>The engagement is conducted outdoors on the Pacifica coast or Skyline ridge—not as retreat, but as diagnostic instrument. Distance from the conference room activates a different cognitive posture. Leaders say things on a trail they would not say in a boardroom. The landscape itself—reading ten living features anchored in 3,000 years of Aramai Ohlone observation—trains the eye and ear for signal detection. This is the posture AI workforce transformation requires: live reading rather than model application. Adaptability emerges from environments that demand it, not from seminars about it.</p>
+    </div>
+
+    <hr class="op-divider">
+
     <!-- WHAT YOU GET: DELIVERABLES -->
     <div>
       <div class="eyebrow">WHAT YOU GET</div>


### PR DESCRIPTION
Add "Why the Landscape Matters" section to one-pager.

Explains the reasoning and cognitive foundation:
- Landscape as diagnostic instrument, not a retreat
- How pace and distance change what leaders notice and are willing to say
- Connection to 3,000 years of Aramai Ohlone observation tradition
- The specific cognitive posture enabled: live reading rather than model application
- Why adaptability emerges from demanding environments, not seminars

Places this section after WHO IS IT FOR and before DELIVERABLES to establish the foundation of the methodology.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4HcbSaw5QMzrtabDHHh8N)_