### PR TITLE
Remove engagement tiers and use Mori Point image

### DIFF
--- a/one-pager.html
+++ b/one-pager.html
@@ -170,7 +170,7 @@
 
 <!-- HERO -->
 <section class="hero hero-photo-bg" id="main-content">
-  <img src="https://images.unsplash.com/photo-1505142468610-359e7d316be0?auto=format&fit=crop&w=1600&q=80" alt="Pacifica coast, Mori Point" class="hero-bg-img" style="object-position: center 35%;" onerror="this.style.display='none'">
+  <img src="https://images.unsplash.com/photo-1561427364-24e711ae0069?auto=format&fit=crop&w=1600&q=80" alt="Pacifica coast, the field engagement landscape" class="hero-bg-img" style="object-position: center 40%;" onerror="this.style.display='none'">
   <div class="hero-bg-overlay"></div>
   <div class="wrap narrow" style="position: relative; z-index: 2;">
     <div class="eyebrow" style="color: var(--logo-gold);">THE OFFER AT A GLANCE</div>
@@ -271,80 +271,6 @@
             <li>90-day roadmap with ownership and sequencing</li>
             <li>Clarity on long-term implications of each decision</li>
           </ul>
-        </div>
-      </div>
-    </div>
-
-    <hr class="op-divider">
-
-    <!-- FOUR TIERS -->
-    <div id="tiers">
-      <div class="eyebrow">ENGAGEMENT OPTIONS</div>
-      <h2>Four tiers to fit your timeline and depth.</h2>
-      <div class="tiers-stack" style="margin-top: 2rem;">
-        <div class="tier-card" style="border-top-color: var(--logo-red);">
-          <div class="tcard-body">
-            <div class="tcard-name">Trail Diagnostic</div>
-            <div class="tcard-meta">Half day &middot; Individual executive</div>
-            <p class="tcard-desc">A single engagement designed to name the specific adaptive challenge facing the organization. Applied through the Signs Framework on the Pacifica headlands. Output is a concise, actionable written diagnostic.</p>
-            <ul class="tcard-list">
-              <li>30-minute prep call</li>
-              <li>4-hour field engagement</li>
-              <li>Written diagnostic in 7 days</li>
-            </ul>
-          </div>
-          <div class="tcard-foot">
-            <div class="tcard-amount">5K USD</div>
-            <a href="begin.html" class="btn btn-ghost" style="font-size: 0.88rem; padding: 0.6rem 1rem;">Inquire</a>
-          </div>
-        </div>
-
-        <div class="tier-card" style="border-top-color: var(--logo-gold);">
-          <div class="tcard-body">
-            <div class="tcard-name">Catalyst Field Session</div>
-            <div class="tcard-meta">Full day &middot; Up to 4 participants</div>
-            <p class="tcard-desc">The full methodology applied in one working day. Morning on the Pacifica headlands activates signal-reading. Afternoon at the Methuselah grove applies strategic frameworks. Output is a full written diagnostic with priority action map.</p>
-            <ul class="tcard-list">
-              <li>30-minute prep call per person</li>
-              <li>Full-day field engagement</li>
-              <li>Full written diagnostic in 10 days</li>
-              <li>Optional 45-minute review call</li>
-            </ul>
-          </div>
-          <div class="tcard-foot">
-            <div class="tcard-amount">15K USD</div>
-            <a href="begin.html" class="btn btn-ghost" style="font-size: 0.88rem; padding: 0.6rem 1rem;">Inquire</a>
-          </div>
-        </div>
-
-        <div class="tier-card" style="border-top-color: var(--logo-blue);">
-          <div class="tcard-body">
-            <div class="tcard-name">Catalyst Immersive</div>
-            <div class="tcard-meta">4 to 6 weeks &middot; Sustained partnership</div>
-            <p class="tcard-desc">A sustained thinking partnership during active transformation. Two field engagements anchor the arc. Virtual working sessions between them apply frameworks to real in-flight decisions. Output is multiple written documents with organizational design depth you can act on.</p>
-            <ul class="tcard-list">
-              <li>Two full-day field engagements</li>
-              <li>4 to 6 virtual working sessions</li>
-              <li>Organizational design documentation</li>
-              <li>90-day roadmap with structural detail</li>
-            </ul>
-          </div>
-          <div class="tcard-foot">
-            <div class="tcard-amount">55K USD</div>
-            <a href="begin.html" class="btn btn-ghost" style="font-size: 0.88rem; padding: 0.6rem 1rem;">Inquire</a>
-          </div>
-        </div>
-
-        <div class="tier-card tier-card--enterprise">
-          <div class="tcard-body">
-            <div class="tcard-name">Enterprise Engagement</div>
-            <div class="tcard-meta">Team or multi-executive cohort &middot; Bespoke scoping</div>
-            <p class="tcard-desc">Bespoke program for enterprise transformations requiring program-level accountability across a leadership cohort. Emerges from Immersive conversations that expand in scope. Scope, cadence, and structure are set with the client. Pricing set with procurement.</p>
-          </div>
-          <div class="tcard-foot">
-            <div class="tcard-amount">100K+ USD</div>
-            <a href="begin.html" class="btn btn-ghost" style="font-size: 0.88rem; padding: 0.6rem 1rem;">Contact</a>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Remove engagement tiers and use Mori Point image from index.

Changes:
- Remove entire ENGAGEMENT OPTIONS / FOUR TIERS section
- One-pager now focuses on: offer, target audience, deliverables, outcomes, and landscape reasoning
- Replace hero image with the Mori Point photo used on index.html (consistent across site)
- Use same image URL for consistency

The one-pager is now a clean, focused overview that directs readers to sessions.html for engagement details.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4HcbSaw5QMzrtabDHHh8N)_