### PR TITLE
Increase prominence of core value proposition

### DIFF
--- a/one-pager.html
+++ b/one-pager.html
@@ -79,9 +79,10 @@
     }
     .op-thesis p {
       margin: 0;
-      font-size: 1.01rem;
-      line-height: 1.75;
+      font-size: clamp(1.35rem, 2.8vw, 1.8rem);
+      line-height: 1.5;
       color: var(--charcoal);
+      font-family: 'Fraunces', serif;
     }
     .op-thesis strong {
       color: var(--navy);


### PR DESCRIPTION
Increase size of core value proposition.

- Update .op-thesis p to use clamp(1.35rem, 2.8vw, 1.8rem) for prominent, responsive display
- Add Fraunces serif font to match heading hierarchy and importance
- Adjust line-height to 1.5 for tighter, more impactful spacing
- Value proposition now reads as a major section equal to other headings on the page

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4HcbSaw5QMzrtabDHHh8N)_