### PR TITLE
Diagnostic: make progress bar scroll away with page

### DIFF
--- a/preliminary-diagnostic.html
+++ b/preliminary-diagnostic.html
@@ -27,7 +27,6 @@
        ============================================================ */
 
     .diag-progress {
-      position: sticky; top: 65px; z-index: 40;
       height: 2px; background: var(--hairline);
     }
     .diag-progress-fill {


### PR DESCRIPTION
Removes position: sticky from .diag-progress so the bar scrolls out of view as the user scrolls down through a question instead of pinning beneath the nav.