### PR TITLE
Diagnostic CTA: point to Catalyst Field Session (full day)

### DIFF
--- a/preliminary-diagnostic.html
+++ b/preliminary-diagnostic.html
@@ -657,7 +657,7 @@ function renderResult() {
     <section class="cta-panel">
       <div class="wrap">
         <p class="cta-sentence">From a named challenge to a mapped terrain.</p>
-        <p class="diag-cta-body">This diagnostic names the challenge. The Trail Diagnostic maps it — a half-day field session that produces a written capability inventory, surfaces the belief gap between leadership intent and team-level reading, and names the specific organizational moves required.</p>
+        <p class="diag-cta-body">This diagnostic names the challenge. The Catalyst Field Session maps it — a full-day engagement across two landscapes, with up to four leaders, that produces a written capability inventory, surfaces the belief gap between leadership intent and team-level reading, and names the specific organizational moves required across every seam.</p>
         <div class="btn-row" style="justify-content:center;">
           <a class="btn btn-primary" href="begin.html">Begin a conversation</a>
           <button class="btn btn-ghost" id="diag-restart">Retake the diagnostic</button>


### PR DESCRIPTION
The result-page CTA was recommending the half-day Trail Diagnostic. That tier only covers a single near-term decision or one named adaptive challenge. The AI Adoption Stall Diagnostic spans all the seams, so the right next step is the Catalyst Field Session — full day, two landscapes (Pacifica coast and Skyline ridge), up to four leaders. Copy updated accordingly.