### PR TITLE
Diagnostic Q12 subtext: align to Catalyst Field Session

### DIFF
--- a/preliminary-diagnostic.html
+++ b/preliminary-diagnostic.html
@@ -442,7 +442,7 @@ const QUESTIONS = [
     { t: "Exactly where adoption is stalling — and whether it is an access, activation, or belief problem.", d: "60% of workers have access. Fewer than 60% of those use AI daily. The gap has a name. Locating where it sits in your organization is the diagnostic question. Deloitte 2026", s: { Seam: 2, Sensing: 1 } },
     { t: "How to move from surface-level efficiency to actual operating model redesign.", d: "37% of organizations are in the surface tier. 'Roles, skills, and career paths should be rebuilt, not simply adjusted — organizations must redesign work holistically.' Deloitte 2026", s: { OM: 3 } },
     { t: "How to align the leadership team on what this transition actually requires — not the tools, the organizational moves.", d: "Enterprises where senior leadership actively shapes AI governance achieve significantly greater business value than those delegating to technical teams. Deloitte 2026", s: { UP: 3 } },
-    { t: "What specific organizational moves to make in the next 90 days.", d: "The Trail Diagnostic produces a written capability map, a named adaptive challenge, and a 90-day roadmap — grounded in a half-day field session with leadership. TDcatalyst", s: { OM: 1, Sensing: 1 } }
+    { t: "What specific organizational moves to make in the next 90 days.", d: "The Catalyst Field Session produces a written capability map, a named adaptive challenge, and a 90-day roadmap — grounded in a full-day field engagement with leadership across two landscapes. TDcatalyst", s: { OM: 1, Sensing: 1 } }
   ]}
 ];
 


### PR DESCRIPTION
The last option's data line on Q12 still mentioned the Trail Diagnostic and a half-day session. Aligning to the Catalyst Field Session (full day, two landscapes) to match the result-page CTA — the diagnostic spans all the seams, which is the full-day scope.