### PR TITLE
Diagnostic: simpler Seam first move

### DIFF
--- a/preliminary-diagnostic.html
+++ b/preliminary-diagnostic.html
@@ -455,7 +455,7 @@ const ARCHETYPES = {
       "What looks like an adoption problem is more precisely a governance problem — and more specifically, a table problem. The wrong people have been in the room where the decisions happen. The three disciplines AI transformation requires — product, operations, and people — rarely sit together. Each underweights what the others know. The seam between them is where most transformations stall."
     ],
     moves: [
-      "Name what people in the organization actually need from leadership to act on AI — clarity on direction, on what AI is supposed to produce inside their scope, on how their roles will change. Then make the organizational work that clarity requires visible: product redesign, operating-model redesign, role-level work, manager enablement. That scope sits with the leadership team as a whole — broader than any single function can carry, and the first move is owning it there, not delegating it.",
+      "Add workforce-side design to the AI strategy from the start — role redesign, manager enablement, and the change work that turns tool access into actual usage. When it gets added after the technology decisions are already locked, the operating model is shaped without it.",
       "Map the seam between product, operations, and people explicitly. Name where handoffs break, where accountability is unclear, where each function pulls in a different direction.",
       "The 90-day work is not more training or a better rollout campaign. It is redesigning the room the transformation is run from."
     ],


### PR DESCRIPTION
Names the workforce-side contribution that's missing from the AI strategy (role redesign, manager enablement, change work) without naming who carries it or editorializing about ownership. About half the length of the previous version, less opinionated.