### PR TITLE
Improve hero challenges boxes spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -192,8 +192,8 @@ section { padding: 5rem 0; }
 .challenges-boxes {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 2rem;
-  margin: 2.5rem 0;
+  gap: 2.5rem;
+  margin: 3rem 0;
   padding: 0;
 }
 .challenge-box {
@@ -209,7 +209,7 @@ section { padding: 5rem 0; }
   font-size: 1rem;
   font-weight: 500;
   color: var(--navy);
-  margin-bottom: 0.6rem;
+  margin-bottom: 1rem;
   line-height: 1.25;
 }
 .challenge-box-detail {


### PR DESCRIPTION
## Summary
Refined spacing on the hero section's three-column challenges boxes to align with the design system and improve visual hierarchy.

**Changes:**
- `.challenges-boxes` margin: 2.5rem → 3rem (adds breathing room above/below)
- `.challenges-boxes` gap: 2rem → 2.5rem (columns feel parallel, not grouped)
- `.challenge-box-title` margin-bottom: 0.6rem → 1rem (snaps off-scale value; title/detail now read as distinct)

**Why:**
- All values now on the 0.5/1/1.5/2/2.5/3 rem design scale
- Aligns with recent spacing optimization commits
- No changes to mobile layout (< 900px breakpoint unchanged)
- 3 lines edited, no new classes/properties

https://claude.ai/code/session_01VRhA29wz86JiufMW3LG1P6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRhA29wz86JiufMW3LG1P6)_