### PR TITLE
Keep Asksila widget only on about page

### DIFF
--- a/begin.html
+++ b/begin.html
@@ -182,12 +182,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/field-note-adaptability-as-a-discipline.html
+++ b/field-note-adaptability-as-a-discipline.html
@@ -245,12 +245,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/field-note-the-adoption-matrix.html
+++ b/field-note-the-adoption-matrix.html
@@ -268,12 +268,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/field-note-the-seams.html
+++ b/field-note-the-seams.html
@@ -230,12 +230,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/field-notes.html
+++ b/field-notes.html
@@ -195,12 +195,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -196,12 +196,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/method.html
+++ b/method.html
@@ -296,12 +296,5 @@
 </footer>
 
 <script src="script.js"></script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/preliminary-diagnostic.html
+++ b/preliminary-diagnostic.html
@@ -1127,12 +1127,5 @@ function render() {
 
 render();
 </script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>

--- a/sessions.html
+++ b/sessions.html
@@ -439,12 +439,5 @@
     });
   });
 </script>
-
-<script
-  src="https://www.asksila.com/widget.js"
-  data-slug="thomas-delaporte"
-  data-position="bottom-right"
-  async
-></script>
 </body>
 </html>


### PR DESCRIPTION
Remove Asksila digital twin widget from all pages except about.html, per user request.

The widget is now only visible on the About page where Thomas is introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYUHAnK4L41fbpg1UnUgzF)_