### PR TITLE
Remove 'Explore the Method' button from diagnostics intro

### DIFF
--- a/sail/preliminary-diagnostic.html
+++ b/sail/preliminary-diagnostic.html
@@ -638,7 +638,6 @@ function renderIntro() {
         <p class="hero-sub" style="margin-bottom: 2rem;">Twelve questions. Four minutes. One named diagnosis — the archetype of your organization's current AI transformation state, and three organizational moves to begin addressing it.</p>
         <div class="btn-row" style="margin-top: 0;">
           <button class="btn btn-primary" id="diag-begin">Begin the diagnostic</button>
-          <a class="btn btn-ghost" href="method.html">Explore the Method</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Remove the 'Explore the Method' button from the diagnostics page intro section, leaving only the 'Begin the diagnostic' button.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcQBSLxp631kBCySvyqaE4)_