### PR TITLE
Specify workforce exchange customer practice on grow and advise pages

### DIFF
--- a/advise/index.html
+++ b/advise/index.html
@@ -46,7 +46,7 @@
     </div>
     <div class="eyebrow">TDcatalyst Advise &middot; For founders moving upmarket</div>
     <h1>Your product is ready for the enterprise. Is your company?</h1>
-    <p class="hero-sub">Scaling from a few million in ARR to your first Fortune 100 account requires a different motion. Enterprise buyers move your product through procurement, security review, the works council, and the CHRO's risk calculus — and decide on a question no demo answers: what happens to our people when this works? Advise gets you through that gauntlet with logos, renewals, and a repeatable motion to show for it. Direct, standing access to the operator who built exactly this — an eight-figure enterprise business at an AI company, from a standing start.</p>
+    <p class="hero-sub">Scaling from a few million in ARR to your first Fortune 100 account requires a different motion. Enterprise buyers move your product through procurement, security review, the works council, and the CHRO's risk calculus — and decide on a question no demo answers: what happens to our people when this works? Advise gets you through that gauntlet with logos, renewals, and a repeatable motion to show for it. Direct, standing access to the operator who built the workforce exchange customer practice — an eight-figure enterprise business at an AI company, from a standing start.</p>
     <div class="btn-row">
       <a href="#begin" class="btn btn-primary">Book a Fit Call</a>
       <a href="#offer" class="btn btn-ghost">See the offer</a>
@@ -99,7 +99,7 @@
       <div class="outcome-item">
         <div class="outcome-num">01</div>
         <h3>Eightfold AI</h3>
-        <p>Built the talent-transformation customer practice from a standing start into an eight-figure ARR business across Fortune 100 and public-sector accounts — the upmarket motion you are attempting, executed inside an AI startup scaling into the enterprise. Deals won through procurement, pilots converted, renewals held.</p>
+        <p>Built the workforce exchange customer practice from a standing start into an eight-figure ARR business across Fortune 100 and public-sector accounts — the upmarket motion you are attempting, executed inside an AI startup scaling into the enterprise. Deals won through procurement, pilots converted, renewals held.</p>
       </div>
       <div class="outcome-item">
         <div class="outcome-num">02</div>

--- a/grow/index.html
+++ b/grow/index.html
@@ -46,7 +46,7 @@
     </div>
     <div class="eyebrow">TDcatalyst Grow &middot; Enterprise &amp; public sector</div>
     <h1>Most organizations don't have an AI problem. They have a portfolio problem.</h1>
-    <p class="hero-sub">Forty pilots, three platforms, no shared definition of done. Adoption that peaks at launch and decays by quarter's end. An org chart designed for work AI has already changed. Grow is fixed-scope consulting that converts that picture into three outcomes: a portfolio with funding decisions made, adoption that holds after the spotlight moves, and an organization that matches the work. Delivered personally by Tom Delaporte — the operator who built an eight-figure AI transformation business at Eightfold AI, on consulting foundations from Capgemini.</p>
+    <p class="hero-sub">Forty pilots, three platforms, no shared definition of done. Adoption that peaks at launch and decays by quarter's end. An org chart designed for work AI has already changed. Grow is fixed-scope consulting that converts that picture into three outcomes: a portfolio with funding decisions made, adoption that holds after the spotlight moves, and an organization that matches the work. Delivered personally by Tom Delaporte — the operator who built an eight-figure workforce exchange customer practice at Eightfold AI, on consulting foundations from Capgemini.</p>
     <div class="btn-row">
       <a href="#begin" class="btn btn-primary">Book a Fit Call</a>
       <a href="#services" class="btn btn-ghost">See the engagements</a>
@@ -96,7 +96,7 @@
       <div class="outcome-item">
         <div class="outcome-num">01</div>
         <h3>Eightfold AI</h3>
-        <p>Built the talent-transformation customer practice from a standing start into an eight-figure ARR business across Fortune 100 and public-sector clients. Led the Talent Transformation, Talent Intelligence Platform, and Agentic Scale programs — the deployment, adoption, and workforce work this page offers, run inside live accounts.</p>
+        <p>Built the workforce exchange customer practice from a standing start into an eight-figure ARR business across Fortune 100 and public-sector clients. Led the Workforce Exchange, Talent Intelligence Platform, and Agentic Scale programs — the deployment, adoption, and workforce work this page offers, run inside live accounts.</p>
       </div>
       <div class="outcome-item">
         <div class="outcome-num">02</div>


### PR DESCRIPTION
Updated Eightfold AI references to accurately describe the workforce exchange customer practice (not talent transformation) that was built from a standing start into an eight-figure ARR business.

Changes:
- grow/index.html: Updated hero and case study to specify "workforce exchange customer practice"
- advise/index.html: Updated hero and case study to specify "workforce exchange customer practice"

---
_Generated by [Claude Code](https://claude.ai/code/session_01MD1b3obeiLgoxtTGad5BoR)_