### PR TITLE
Reword diagnostic sources credit to avoid overstated proprietary claim

### DIFF
--- a/sail/preliminary-diagnostic.html
+++ b/sail/preliminary-diagnostic.html
@@ -713,6 +713,7 @@ function renderIntro() {
             <p><strong>SHRM, 2026</strong> — Chief Human Resources Officer AI adoption and governance data.</p>
             <p><strong>Teece, Dynamic Capabilities</strong> — Foundational framework for sensing, seizing, and transforming organizational capabilities.</p>
             <p><strong>ServiceNow, 2026</strong> — Chief People and AI Enablement Officer role appointment as emerging organizational structure.</p>
+            <p><strong>TDcatalyst</strong> — Proprietary frameworks on adoption theater, structural stalls, and adaptive organizational design.</p>
           </div>
         </details>
       </div>

--- a/sail/preliminary-diagnostic.html
+++ b/sail/preliminary-diagnostic.html
@@ -713,7 +713,7 @@ function renderIntro() {
             <p><strong>SHRM, 2026</strong> — Chief Human Resources Officer AI adoption and governance data.</p>
             <p><strong>Teece, Dynamic Capabilities</strong> — Foundational framework for sensing, seizing, and transforming organizational capabilities.</p>
             <p><strong>ServiceNow, 2026</strong> — Chief People and AI Enablement Officer role appointment as emerging organizational structure.</p>
-            <p><strong>TDcatalyst</strong> — Proprietary frameworks on adoption theater, structural stalls, and adaptive organizational design.</p>
+            <p><strong>TDcatalyst</strong> — Original synthesis and diagnostic frameworks for adoption theater, structural stalls, and adaptive organizational design.</p>
           </div>
         </details>
       </div>

--- a/sail/preliminary-diagnostic.html
+++ b/sail/preliminary-diagnostic.html
@@ -713,7 +713,6 @@ function renderIntro() {
             <p><strong>SHRM, 2026</strong> — Chief Human Resources Officer AI adoption and governance data.</p>
             <p><strong>Teece, Dynamic Capabilities</strong> — Foundational framework for sensing, seizing, and transforming organizational capabilities.</p>
             <p><strong>ServiceNow, 2026</strong> — Chief People and AI Enablement Officer role appointment as emerging organizational structure.</p>
-            <p><strong>TDcatalyst</strong> — Proprietary frameworks on adoption theater, structural stalls, and adaptive organizational design.</p>
           </div>
         </details>
       </div>


### PR DESCRIPTION
Reworks the TDcatalyst entry in the Sources list on the AI Transformation Stall Diagnostic (`sail/preliminary-diagnostic.html`).

"Adoption theater" is part of a common "-theater" rhetorical family (security/innovation/compliance theater) and the language circulates publicly, so claiming it as "Proprietary frameworks" overstated ownership. The credit is reframed around the practice's genuine contribution — the original synthesis and diagnostic instrument — rather than ownership of the term.

Before: *TDcatalyst — Proprietary frameworks on adoption theater, structural stalls, and adaptive organizational design.*
After: *TDcatalyst — Original synthesis and diagnostic frameworks for adoption theater, structural stalls, and adaptive organizational design.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JR9AAbWZ9R1xFu3MQQS33b)_